### PR TITLE
panic 没有处理异常 在开放接口很容易丢异常排查困难

### DIFF
--- a/request.go
+++ b/request.go
@@ -126,7 +126,7 @@ func (this *Request) Send(url string, method string) (*Response, error) {
 	var payload io.Reader
 	if method == "POST" && this.PostData != nil {
 		if jData, err := json.Marshal(this.PostData); err != nil {
-			panic(err)
+			return nil, err
 		} else {
 			payload = bytes.NewReader(jData)
 		}

--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ package curl
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 )
@@ -109,22 +110,18 @@ func (this *Request) Post() (*Response, error) {
 
 // 发起请求
 func (this *Request) Send(url string, method string) (*Response, error) {
-	// 初始化Response对象
-	response := NewResponse()
-
-	// 初始化http.Client对象
-	this.cli = &http.Client{}
-
 	// 检测请求url是否填了
 	if url == "" {
-		panic("Lack of request url")
+		return nil, errors.New("Lack of request url")
 	}
-
 	// 检测请求方式是否填了
 	if method == "" {
-		panic("Lack of request method")
+		return nil, errors.New("Lack of request method")
 	}
-
+	// 初始化Response对象
+	response := NewResponse()
+	// 初始化http.Client对象
+	this.cli = &http.Client{}
 	// 加载用户自定义的post数据到http.Request
 	var payload io.Reader
 	if method == "POST" && this.PostData != nil {
@@ -138,7 +135,7 @@ func (this *Request) Send(url string, method string) (*Response, error) {
 	}
 
 	if req, err := http.NewRequest(method, url, payload); err != nil {
-		panic(err)
+		return nil, err
 	} else {
 		this.req = req
 	}
@@ -150,7 +147,7 @@ func (this *Request) Send(url string, method string) (*Response, error) {
 	this.Raw = this.req
 
 	if resp, err := this.cli.Do(this.req); err != nil {
-		panic(err)
+		return nil, err
 	} else {
 		response.Raw = resp
 	}


### PR DESCRIPTION
我在用您 的request.go 发送请求时，经常 会丢异常 不小心就崩溃以为err接收判定就没事了，看了您 的源码才知道是直接 丢异常 ，被 我改成返回err 方式 取消 掉panic ，希望 您 能合并。